### PR TITLE
Update GridNos in creature-lairs JSON

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -10,5 +10,5 @@
 
 - Departing Mercs leave their equipment in an open tile
 - Equipment of captured mercs is placed in the open
-- Squad may get stuck after using the "Travel to surface" function from deep
-  underground. In that case, traverse out and back in the sector in stratigic map.
+- Some underground sectors are not drawn correctly on strategic map
+- Water fountain at Kingpin's mansion not drawn properly

--- a/assets/wildfire-maps/Data/strategic-map-creature-lairs.json
+++ b/assets/wildfire-maps/Data/strategic-map-creature-lairs.json
@@ -1,0 +1,170 @@
+[
+    {
+        "associatedMineId": 1, // Drassen
+        "lairId": 1,
+        "sectors": [
+            [ "F13", 3, "QUEEN_LAIR" ],
+            [ "G13", 3, "LAIR" ],
+            [ "G13", 2, "LAIR_ENTRANCE" ],
+            [ "F13", 2, "INNER_MINE" ],
+            [ "E13", 2, "INNER_MINE" ],
+            [ "E13", 1, "OUTER_MINE" ],
+            [ "D13", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "E13", 1 ],
+        "warpExit": {
+            "sector": "D13",
+            "gridNo": 17030
+        },
+        "attackSectors": [
+            {
+                "sector": "D13",
+                "chance": 45,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 16864
+            },
+            {
+                "sector": "C13",
+                "chance": 25,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "B13",
+                "chance": 30,
+                "insertionCode": "SOUTH"
+            }
+        ]
+    },
+    {
+        "lairId": 2,
+        "associatedMineId": 3, // Cambria
+        "sectors": [
+            [ "J8", 3, "QUEEN_LAIR" ],
+            [ "I8", 3, "LAIR" ],
+            [ "H8", 3, "LAIR" ],
+            [ "H8", 2, "LAIR_ENTRANCE" ],
+            [ "H9", 2, "INNER_MINE" ],
+            [ "H9", 1, "OUTER_MINE" ],
+            [ "H8", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "H9", 1 ],
+        "warpExit": {
+            "sector": "H8",
+            "gridNo": 10505
+        },
+        "attackSectors": [
+            {
+                "sector": "H8",
+                "chance": 35,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 9034
+            },
+            {
+                "sector": "G8",
+                "chance": 20,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "F8",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "G9",
+                "chance": 15,
+                "insertionCode": "WEST"
+            },
+            {
+                "sector": "F9",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            }
+        ]
+    },
+    {
+        "lairId": 3,
+        "associatedMineId": 2, // Alma
+        "sectors": [
+            [ "K13", 3, "QUEEN_LAIR" ],
+            [ "J13", 3, "LAIR" ],
+            [ "J13", 2, "LAIR_ENTRANCE" ],
+            [ "J14", 2, "INNER_MINE" ],
+            [ "J14", 1, "OUTER_MINE" ],
+            [ "I14", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "J14", 1 ],
+        "warpExit": {
+            "sector": "I14",
+            "gridNo": 6315
+        },
+        "attackSectors": [
+            {
+                "sector": "I14",
+                "chance": 45,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 6151
+            },
+            {
+                "sector": "I13",
+                "chance": 20,
+                "insertionCode": "EAST"
+            },
+            {
+                "sector": "H14",
+                "chance": 20,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "H13",
+                "chance": 15,
+                "insertionCode": "EAST"
+            }
+        ]
+    },
+    {
+        "lairId": 4,
+        "associatedMineId": 5, // Grumm
+        "sectors": [
+            [ "G4", 3, "QUEEN_LAIR" ],
+            [ "H4", 3, "LAIR" ],
+            [ "H4", 2, "LAIR_ENTRANCE" ],
+            [ "H3", 2, "INNER_MINE" ],
+            [ "I3", 2, "INNER_MINE" ],
+            [ "I3", 1, "OUTER_MINE" ],
+            [ "H3", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "H4", 2 ],
+        "warpExit": {
+            "sector": "H3",
+            "gridNo": 9846
+        },
+        "attackSectors": [
+            {
+                "sector": "H3",
+                "chance": 35,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 9364
+            },
+            {
+                "sector": "H2",
+                "chance": 20,
+                "insertionCode": "EAST"
+            },
+            {
+                "sector": "G2",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "H1",
+                "chance": 15,
+                "insertionCode": "EAST"
+            },
+            {
+                "sector": "G1",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
To fix the known issue with warp exit from lairs, and as follow up of https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1106.

The JSON is the same as vanilla except the gridNos. New town sectors are not considered.

### Diff from Vanilla strategic-map-creature-lairs.json:
```diff
1,11d0
< /*
<  * Defines all the possible Crepitus creature lairs and spreading. There can be at most 1 lair activated in each (Sci-Fi) game.
<  *
<  * Field definitions:
<  *  - lairId:    A unique numeric ID for the lair. Must be an integer greater than zero.
<  *  - associatedMineId:    Creature lair must be located and associated with one mine.
<  *  - entranceSector:    Where the lair entrance is located. There must be an alternate map file (*_a.dat), which will be activated at lair initialization.
<  *  - sectors:    This should be a consecutive, non-branching, ordered list of underground sectors making up the lair, specified as an array of [sector, sectorZ, habitatType]. This list should start with the innermost sector, which is the QUEEN_LAIR. The creatures will spread out outwards. Each sector must have a corresponding map file and defined in strategic-map-underground-sectors.json; "habitatType" must be one of: QUEEN_LAIR, LAIR, LAIR_ENTRANCE, INNER_MINE, OUTER_MINE, FEEDING_GROUNDS or MINE_EXIT. See Creature_Spreading.h for details.
<  *  - warpExit:    Destination for the "Travel to surface?" warp from deep underground
<  *  - attackSectors: List of town sectors and enemy insertion. Used by creatures to make town attacks. Each entry can have four fields: 1) sector, which should be a nearby town sector; 2) chance, which is an integer weight on how likely the sector is chosen for the next attack; 3) insertionCode: any one from the INSERTION_CODE_* enum but without the prefix, such as "GRIDNO", "NORTH", "CENTER"; 4) insertionGridNo: optional GridNo, required only if the insertionCode is "GRIDNO"
<  */
28c17
<             "gridNo": 20700
---
>             "gridNo": 17030
35c24
<                 "insertionGridNo": 20703
---
>                 "insertionGridNo": 16864
64c53
<             "gridNo": 13002
---
>             "gridNo": 10505
71c60
<                 "insertionGridNo": 13005
---
>                 "insertionGridNo": 9034
109c98
<             "gridNo": 9085
---
>             "gridNo": 6315
116c105
<                 "insertionGridNo": 9726
---
>                 "insertionGridNo": 6151
150c139
<             "gridNo": 9822
---
>             "gridNo": 9846
157c146
<                 "insertionGridNo": 10303
---
>                 "insertionGridNo": 9364
```