### PR TITLE
Ensuring Python 3 on Mac build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ jobs:
     os: osx
     osx_image: xcode11.2
     language: shell
+    before_install:
+    - pyenv install 3.8.2 && pyenv shell 3.8.2
   - name: Python 3.8 on Windows
     os: windows
     language: bash


### PR DESCRIPTION
#5 sounds like issue with Python version - `pathlib` was added in Python 3.4

Using `pyenv` to ensure we have a new enough version of Python 3.