### PR TITLE
Adapt NPC placements to new schema for 0.19.x

### DIFF
--- a/assets/wildfire-maps/Data/strategic-map-npc-placements.json
+++ b/assets/wildfire-maps/Data/strategic-map-npc-placements.json
@@ -1,46 +1,46 @@
 [
 	{
-		"profileId": 63,    // HAMOUS, together with his Ice-cream truck (PROF_ICECREAM, 162)
+		"profile": "HAMOUS",    // HAMOUS, together with his Ice-cream truck (PROF_ICECREAM, 162)
 		"sectors": [ "G6", "F12", "D7", "C3", "D9" ],
 		"placedAtStart": false
 	},
 	{
-		"profileId": 61,    // DEVIN
+		"profile": "DEVIN",    // DEVIN
 		"sectors": [ "G9", "D13", "C5", "H2", "C6" ],
 		"placedAtStart": false
 	},
 	{
-		"profileId": 78,    // CARMEN
+		"profile": "CARMEN",    // CARMEN
 		"sectors": [ "C5", "C13", "G9" ],
 		"placedAtStart": false
 	},
 	/* NPCs randomly placed at game start */
 	{
-		"profileId": 97,    // SKYRIDER
+		"profile": "SKYRIDER",    // SKYRIDER
 		"sectors": [ "B15", "E14", "D12", "C16" ],
 		"placedAtStart": true,
 		"useAlternateMap": true
 	},
 	{
-		"profileId": 146,   // MADLAB (and ROBOT)
+		"profile": "MADLAB",   // MADLAB (and ROBOT)
 		"sectors": [ "H7", "H16", "I11", "E4" ],
 		"placedAtStart": false,
 		"useAlternateMap": true
 	},
 	{
-		"profileId": 96,    // MICKY
+		"profile": "MICKY",    // MICKY
 		"sectors": [ "G9", "D13", "C5", "H2", "C6" ],
 		"placedAtStart": true
 	},
 	/* Sci-fi mode only NPCs */
 	{
-		"profileId": 84,    // BOB
+		"profile": "BOB",    // BOB
 		"sectors": [ "F8" ],
 		"placedAtStart": true,
 		"sciFiOnly": true
 	},
 	{
-		"profileId": 104,   // GABBY
+		"profile": "GABBY",   // GABBY
 		"sectors": [ "H11", "I4" ],
 		"placedAtStart": true,
 		"sciFiOnly": true,


### PR DESCRIPTION
But I found another issue with `0.19.x` unfortunately which needs to be fixed in the ja2-stracciatella repo:

The schema for `tactical-map-item-replacements.json` only allows `uint8` as the numeric index, it should be `uint16` for an item id though. Unfortunately this mod uses an item index that is larger than what fits into a `uint8`.