### PR TITLE
Fix installer build

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ${{ matrix.cfg.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-      with: 
+      uses: actions/checkout@v4
+      with:
         submodules: true
 
     - name: Set up Python
@@ -41,11 +41,31 @@ jobs:
     - name: Set up build deps
       shell: bash
       run: |
-        pip3 install setuptools==58 wheel  ## needed by fs<2
-        if [ "${{ matrix.cfg.target }}" = "linux"   ]; then sudo apt-get -yq update && sudo apt-get -yq install upx; fi
-        if [ "${{ matrix.cfg.target }}" = "windows" ]; then pip3 install pypiwin32 pefile; fi
+        pip3 install --upgrade pip
 
-        pip3 install -r build/requirements.txt
+        if [ "${{ matrix.cfg.target }}" = "linux" ]; then
+          sudo apt-get -yq update && sudo apt-get -yq install upx zlib1g-dev libjpeg-dev libfreetype6-dev
+        fi
+
+        if [ "${{ matrix.cfg.target }}" = "mac" ]; then
+          brew install zlib libjpeg freetype
+          export LDFLAGS="-L/opt/homebrew/opt/zlib/lib"
+          export CFLAGS="-I/opt/homebrew/opt/zlib/include"
+        fi
+
+        if [ "${{ matrix.cfg.target }}" = "windows" ]; then
+          vcpkg install zlib:x86-windows libjpeg-turbo:x86-windows
+          vcpkg integrate install
+          pip3 install pypiwin32 pefile
+          export VCPKG_ROOT="C:\vcpkg"
+          export VCPKG_DEFAULT_TRIPLET="x86-windows"
+          export INCLUDE="$VCPKG_ROOT\installed\x86-windows\include;$INCLUDE"
+          export LIB="$VCPKG_ROOT\installed\x86-windows\lib;$LIB"
+          export CFLAGS="-I$VCPKG_ROOT\installed\x86-windows\include"
+          export LDFLAGS="-L$VCPKG_ROOT\installed\x86-windows\lib"
+        fi
+
+        pip3 install --prefer-binary -r build/requirements.txt
         pip3 install pyinstaller
 
     - name: Determine package version

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/ja2-open-toolset"]
-	path = lib/ja2-open-toolset
-	url = https://github.com/ja2-stracciatella/ja2-open-toolset.git

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,3 +1,4 @@
-fs==0.5.4
+fs==2.4.16
 Pillow>=4.1.0
 colorama==0.4.3
+git+https://github.com/ja2-stracciatella/ja2-open-toolset.git@7a0b6778bfbba500c0d34942f0d7452e2cac7f0f 

--- a/src/install_wildfire_maps.py
+++ b/src/install_wildfire_maps.py
@@ -147,7 +147,7 @@ def unpack_slf(src_path, work_path, slf_name):
     combined_fs = open_slf_for_copy(src_path, work_path, slf_name)
 
     print("  * Unpacking " + slf_name)
-    combined_fs.copydir('/slf', '/out', overwrite=True)
+    combined_fs.copydir('slf', 'out')
     combined_fs.close()
 
 
@@ -180,6 +180,7 @@ def find_slf_that_contains_resource(src_path, resource_path):
                 return slf_filename[:-4], r
     return None, None
 
+
 def open_slf_for_copy(src_path, dest_path, slf_name):
     """Opens an SLF files for reading and returns a MountFS"""
     slf_filename = resolve_case_insensitive_path(src_path, slf_name + ".slf")
@@ -191,10 +192,11 @@ def open_slf_for_copy(src_path, dest_path, slf_name):
     out_fs = OSFS(output_dir)
 
     combined_fs = MountFS()
-    combined_fs.mountdir('slf', slf_fs)
-    combined_fs.mountdir('out', out_fs)
+    combined_fs.mount('slf', slf_fs)
+    combined_fs.mount('out', out_fs)
 
     return combined_fs
+
 
 def convert_bmap(work_path):
     """Converts the bmap.sti in Wildfire to bmap.pcx which is needed by Vanilla/JA2:S"""
@@ -240,7 +242,7 @@ if __name__ == '__main__':
     try:
         main()
     except Exception as e:
-        print("\n" + Fore.RED + str(e) + Fore.RESET)
+        print("\n " + Fore.RED + repr(e) + Fore.RESET)
         if is_verbose:
             print(Style.DIM + Fore.BLUE + "\nError traceback:\n")
             traceback.print_exc()


### PR DESCRIPTION
Resolves https://github.com/ja2-stracciatella/mod-wildfire-maps/issues/26.

Depends on https://github.com/ja2-stracciatella/ja2-open-toolset/pull/14.

---

The installer code and the `ja2-open-toolset` library uses an old version of `fs` which no longer works. This upgrades it to better support current Python versions.